### PR TITLE
update deployment template to allow custom labels

### DIFF
--- a/helm/polarbearblog/templates/deployment.yaml
+++ b/helm/polarbearblog/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        {{- if .Values.labels -}}
+        {{ toYaml .Values.labels | nindent 8 }}
+        {{- end -}}
         {{- include "polarbearblog.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
Current deployment template doesn't allow having custom labels from values files. This PR updates the template to allow custom labels.